### PR TITLE
feat: Add GitHub Actions workflows for release and semantic PR validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm i --no-fund --no-audit
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
+          # OIDC: No NPM_TOKEN needed when using Trusted Publishing
+        run: npx semantic-release
+
+      - name: Verify npm publish via OIDC
+        if: failure()
+        run: |
+          echo "If publish failed, ensure this repo is configured as an npm Trusted Publisher (OIDC) and package name is claimed."

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,20 @@
+name: Semantic PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Defaults validate Conventional Commits types/scopes/subject.
+        # Configure via `.github/semantic.yml` if you need custom types or scopes.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "release": "semantic-release"
   },
   "author": "Harris Sidiropoulos",
   "license": "ISC",
@@ -37,6 +38,54 @@
     "eslint-plugin-sonarjs": "^0.19.0",
     "eslint-plugin-unicorn": "^46.0.0",
     "eslint-plugin-yml": "^1.5.0",
-    "prettier": "^2.8.7"
+    "prettier": "^2.8.7",
+    "@semantic-release/changelog": "^6.0.0",
+    "@semantic-release/commit-analyzer": "^13.0.0",
+    "@semantic-release/git": "^10.0.0",
+    "@semantic-release/github": "^10.0.0",
+    "@semantic-release/npm": "^11.0.0",
+    "@semantic-release/release-notes-generator": "^14.0.0",
+    "semantic-release": "^23.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "release": {
+    "branches": [
+      "main"
+    ],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/changelog",
+        {
+          "changelogFile": "CHANGELOG.md"
+        }
+      ],
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": true
+        }
+      ],
+      "@semantic-release/github",
+      [
+        "@semantic-release/git",
+        {
+          "assets": [
+            "CHANGELOG.md",
+            "package.json",
+            "package-lock.json",
+            "npm-shrinkwrap.json"
+          ],
+          "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
Automates releases with `semantic-release` and publishes to npm via GitHub OIDC (Trusted Publishers).  
Adds a PR title check to enforce [Conventional Commits](https://www.conventionalcommits.org/) when using squash merges.

---

## 📦 What’s Included

### `semantic-release` configuration in `package.json`:
- `scripts.release`
- Release plugins:
  - `@semantic-release/commit-analyzer`
  - `@semantic-release/release-notes-generator`
  - `@semantic-release/changelog`
  - `@semantic-release/npm`
  - `@semantic-release/github`
  - `@semantic-release/git`
- `publishConfig`:  
  ```json
  {
    "access": "public",
    "provenance": true
  }
  ```
- `engines`: Node >=18

### Release workflow (`.github/workflows/release.yml`):
- Triggers on push to `main`
- `permissions`:  
  ```yaml
  id-token: write  # for OIDC
  contents: write
  issues: write
  pull-requests: write
  ```
- Uses Node 20
- Runs `npm ci` (fallback to `npm i`)
- Runs `npx semantic-release` (no `NPM_TOKEN` required)

### Semantic PR workflow (`.github/workflows/semantic-pr.yml`):
- Validates PR titles against Conventional Commits  
  → via [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request)

---

## ❓ Why

- Consistent semantic versioning and automated changelog + GitHub Releases
- Secure npm publishing without long‑lived tokens via OIDC Trusted Publishing
- Better release signal by enforcing semantic PR titles when squashing

---

## 🛠️ Setup Required (Once)

1. **Enable npm Trusted Publishing** for this package:  
   In npm settings, add GitHub Trusted Publisher and select this repo (`main` branch).
2. _(Optional)_ Protect `main` and require the “Semantic PR Title” check.
3. Ensure Conventional Commits for:
   - Commit messages, or
   - PR titles (when squash merging)

---

## ✅ How to Verify

- Run a dry run:
  ```bash
  npx semantic-release --dry-run
  ```
- Merge a Conventional Commit to `main` (e.g., `feat: ...`)
- Expect:
  - New tag
  - GitHub release
  - `CHANGELOG.md` update
  - npm publish with provenance

---

## 📝 Notes

- `semantic-release` adds `[skip ci]` to its own release commit to avoid CI loops.
- No `CHANGELOG.md` needed upfront — it’s generated on first release.
